### PR TITLE
Add floating language and voice selector for typing modes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,6 +43,94 @@
   color: #475569;
 }
 
+.settings-row {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-control {
+  position: relative;
+}
+
+.settings-control__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: none;
+  background: linear-gradient(120deg, rgba(99, 102, 241, 0.18), rgba(59, 130, 246, 0.3));
+  color: #1e3a8a;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.settings-control__trigger:hover,
+.settings-control__trigger:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px -16px rgba(37, 99, 235, 0.5);
+  outline: none;
+}
+
+.settings-control__trigger:focus-visible {
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.4);
+}
+
+.settings-control__popover {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(280px, 85vw);
+  background: rgba(248, 250, 252, 0.98);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 1rem 1.1rem;
+  box-shadow: 0 24px 60px -40px rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 5;
+}
+
+.settings-control__popover.is-open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.settings-control__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  margin-bottom: 0.75rem;
+}
+
+.settings-control__section:last-of-type {
+  margin-bottom: 0;
+}
+
+.settings-control__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.settings-control__select {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.settings-control__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #ef4444;
+}
+
 .mode-switcher {
   display: flex;
   align-items: center;
@@ -221,6 +309,11 @@
   font-size: 1rem;
   background: rgba(255, 255, 255, 0.96);
   transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+.field__hint {
+  font-size: 0.85rem;
+  color: #94a3b8;
 }
 
 .field__control:focus {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import InputBox from "./components/InputBox";
 import WordList from "./components/WordList";
 import ExerciseConfig from "./components/ExerciseConfig";
 import TypingExercise from "./components/TypingExercise";
+import VoiceLanguageControl from "./components/VoiceLanguageControl";
 import "./App.css";
 
 function App() {
@@ -17,27 +18,6 @@ function App() {
             setWords((prev) => [...prev, word]);
         }
     };
-
-    useEffect(() => {
-        const synth = window.speechSynthesis;
-        const selectVoiceForLang = () => {
-            const allVoices = synth.getVoices();
-            const candidates = allVoices.filter((item) => item.lang.startsWith(lang));
-            if (!candidates.length) return;
-
-            const alreadySelected = candidates.some((candidate) => candidate.name === voice?.name);
-            if (!alreadySelected) {
-                setVoice(candidates[0]);
-            }
-        };
-
-        selectVoiceForLang();
-        synth.addEventListener("voiceschanged", selectVoiceForLang);
-
-        return () => {
-            synth.removeEventListener("voiceschanged", selectVoiceForLang);
-        };
-    }, [lang, voice]);
 
     useEffect(() => {
         if (!exerciseMode) return;
@@ -60,6 +40,15 @@ function App() {
                     <p>{hintText}</p>
                 </header>
 
+                <div className="settings-row">
+                    <VoiceLanguageControl
+                        lang={lang}
+                        voice={voice}
+                        onLangChange={setLang}
+                        onVoiceChange={setVoice}
+                    />
+                </div>
+
                 <div className="mode-switcher" role="group" aria-label="انتخاب حالت تمرین">
                     <span className={`mode-switcher__label ${!exerciseMode ? "is-active" : ""}`}>
                         تمرین آزاد
@@ -79,14 +68,7 @@ function App() {
 
                 {exerciseMode ? (
                     <>
-                        <ExerciseConfig
-                            lang={lang}
-                            voice={voice}
-                            onLangChange={setLang}
-                            onVoiceChange={setVoice}
-                            text={exerciseText}
-                            onTextChange={setExerciseText}
-                        />
+                        <ExerciseConfig text={exerciseText} onTextChange={setExerciseText} />
                         <TypingExercise targetText={exerciseText} voice={voice} />
                     </>
                 ) : (

--- a/src/components/ExerciseConfig.tsx
+++ b/src/components/ExerciseConfig.tsx
@@ -1,98 +1,32 @@
-import { useEffect, useMemo, useState } from "react";
+import type { ChangeEvent } from "react";
 
 type Props = {
-    lang: string;
-    voice: SpeechSynthesisVoice | null;
-    onLangChange: (lang: string) => void;
-    onVoiceChange: (voice: SpeechSynthesisVoice) => void;
     text: string;
     onTextChange: (text: string) => void;
 };
 
-export default function ExerciseConfig({
-                                            lang,
-                                            voice,
-                                            onLangChange,
-                                            onVoiceChange,
-                                            text,
-                                            onTextChange,
-                                        }: Props) {
-    const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
-
-    useEffect(() => {
-        const synth = window.speechSynthesis;
-        const updateVoices = () => setVoices(synth.getVoices());
-
-        updateVoices();
-        synth.addEventListener("voiceschanged", updateVoices);
-
-        return () => {
-            synth.removeEventListener("voiceschanged", updateVoices);
-        };
-    }, []);
-
-    const filteredVoices = useMemo(
-        () => voices.filter((v) => v.lang.startsWith(lang)),
-        [voices, lang]
-    );
-
-    useEffect(() => {
-        if (!filteredVoices.length) return;
-        const alreadySelected = filteredVoices.some((v) => v.name === voice?.name);
-        if (!alreadySelected) {
-            onVoiceChange(filteredVoices[0]);
-        }
-    }, [filteredVoices, onVoiceChange, voice]);
+export default function ExerciseConfig({ text, onTextChange }: Props) {
+    const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+        onTextChange(event.target.value);
+    };
 
     return (
         <section className="card">
             <header className="card__header">
-                <h3>تنظیمات تمرین</h3>
-                <p>زبان، صدای گوینده و متن تمرین خودت را انتخاب کن.</p>
+                <h3>متن تمرین</h3>
+                <p>جمله یا پاراگراف موردنظر را بنویس تا همان متن را در تمرین تایپ کنی.</p>
             </header>
-
-            <div className="form-grid">
-                <label className="field">
-                    <span className="field__label">زبان</span>
-                    <select
-                        className="field__control"
-                        value={lang}
-                        onChange={(e) => onLangChange(e.target.value)}
-                    >
-                        <option value="de-DE">آلمانی 🇩🇪</option>
-                        <option value="en-US">انگلیسی 🇺🇸</option>
-                        <option value="fr-FR">فرانسوی 🇫🇷</option>
-                    </select>
-                </label>
-
-                <label className="field">
-                    <span className="field__label">انتخاب صدا</span>
-                    <select
-                        className="field__control"
-                        value={voice?.name || ""}
-                        onChange={(e) => {
-                            const selected = filteredVoices.find((v) => v.name === e.target.value);
-                            if (selected) onVoiceChange(selected);
-                        }}
-                    >
-                        {filteredVoices.map((v) => (
-                            <option key={v.name} value={v.name}>
-                                {v.name}
-                            </option>
-                        ))}
-                    </select>
-                </label>
-            </div>
 
             <label className="field">
                 <span className="field__label">متن تمرین</span>
                 <textarea
                     className="field__control field__control--textarea"
                     value={text}
-                    onChange={(e) => onTextChange(e.target.value)}
+                    onChange={handleChange}
                     rows={3}
                     placeholder="اینجا جمله یا پاراگراف مورد نظر را بنویس..."
                 />
+                <span className="field__hint">از دکمه بالا برای تغییر زبان و صدای گوینده استفاده کن.</span>
             </label>
         </section>
     );

--- a/src/components/VoiceLanguageControl.tsx
+++ b/src/components/VoiceLanguageControl.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type Props = {
+    lang: string;
+    voice: SpeechSynthesisVoice | null;
+    onLangChange: (lang: string) => void;
+    onVoiceChange: (voice: SpeechSynthesisVoice) => void;
+};
+
+const LANG_OPTIONS: { value: string; label: string }[] = [
+    { value: "de-DE", label: "آلمانی 🇩🇪" },
+    { value: "en-US", label: "انگلیسی 🇺🇸" },
+    { value: "fr-FR", label: "فرانسوی 🇫🇷" },
+];
+
+export default function VoiceLanguageControl({ lang, voice, onLangChange, onVoiceChange }: Props) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        const synth = window.speechSynthesis;
+        const updateVoices = () => setVoices(synth.getVoices());
+
+        updateVoices();
+        synth.addEventListener("voiceschanged", updateVoices);
+
+        return () => {
+            synth.removeEventListener("voiceschanged", updateVoices);
+        };
+    }, []);
+
+    const filteredVoices = useMemo(
+        () => voices.filter((v) => v.lang?.toLowerCase().startsWith(lang.toLowerCase())),
+        [voices, lang]
+    );
+
+    useEffect(() => {
+        if (!filteredVoices.length) return;
+        const hasSelectedVoice = filteredVoices.some((item) => item.name === voice?.name);
+        if (!hasSelectedVoice) {
+            onVoiceChange(filteredVoices[0]);
+        }
+    }, [filteredVoices, voice, onVoiceChange]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const handleClickOutside = (event: MouseEvent) => {
+            if (!containerRef.current) return;
+            if (!containerRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+
+        const handleEsc = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setIsOpen(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        document.addEventListener("keydown", handleEsc);
+
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+            document.removeEventListener("keydown", handleEsc);
+        };
+    }, [isOpen]);
+
+    return (
+        <div className="settings-control" ref={containerRef}>
+            <button
+                type="button"
+                className="settings-control__trigger"
+                onClick={() => setIsOpen((prev) => !prev)}
+                aria-expanded={isOpen}
+                aria-haspopup="true"
+            >
+                <span aria-hidden="true">🎛️</span>
+                تنظیم زبان و صدا
+            </button>
+
+            <div
+                className={`settings-control__popover ${isOpen ? "is-open" : ""}`}
+                role="dialog"
+                aria-modal="false"
+                aria-label="تنظیمات زبان و صدا"
+            >
+                <div className="settings-control__section">
+                    <span className="settings-control__label">زبان تمرین</span>
+                    <select
+                        className="settings-control__select"
+                        value={lang}
+                        onChange={(event) => onLangChange(event.target.value)}
+                    >
+                        {LANG_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className="settings-control__section">
+                    <span className="settings-control__label">انتخاب صدا</span>
+                    {filteredVoices.length ? (
+                        <select
+                            className="settings-control__select"
+                            value={voice?.name ?? filteredVoices[0]?.name ?? ""}
+                            onChange={(event) => {
+                                const selected = filteredVoices.find((item) => item.name === event.target.value);
+                                if (selected) {
+                                    onVoiceChange(selected);
+                                }
+                            }}
+                        >
+                            {filteredVoices.map((item) => (
+                                <option key={item.name} value={item.name}>
+                                    {item.name}
+                                </option>
+                            ))}
+                        </select>
+                    ) : (
+                        <p className="settings-control__empty">هیچ صدایی برای این زبان پیدا نشد.</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add a floating language and voice selector so both practice modes share the same controls without scrolling
- simplify the exercise configuration card to focus on text entry and point to the floating selector
- style the new selector popover to keep the UI compact and accessible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d67c2595a48323aaad323fb38f0147