### PR TITLE
Fix space-triggered speech and adjust exercise text styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -250,14 +250,11 @@
   position: absolute;
   inset: 0;
   padding: 0.85rem 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.25rem;
   pointer-events: none;
   font-size: 1rem;
   line-height: 1.7;
   white-space: pre-wrap;
+  color: #1f2937;
 }
 
 .exercise-input__placeholder {
@@ -268,33 +265,32 @@
 .exercise-input__field {
   color: transparent;
   caret-color: #4338ca;
-  background: rgba(255, 255, 255, 0.9);
+  background: transparent;
 }
 
 .exercise-input__field:focus {
-  background: #ffffff;
+  background: transparent;
 }
 
 .exercise-input__char {
-  padding: 0.1rem 0.2rem;
-  border-radius: 8px;
-  transition: background 0.2s ease, color 0.2s ease;
+  display: inline;
+  transition: color 0.2s ease;
 }
 
 .exercise-input__char--pending {
-  color: #a1aecb;
+  color: #94a3b8;
 }
 
 .exercise-input__char--correct {
-  color: #047857;
-  background: rgba(16, 185, 129, 0.16);
-  font-weight: 600;
+  color: #1f2937;
 }
 
 .exercise-input__char--incorrect {
   color: #dc2626;
-  background: rgba(248, 113, 113, 0.18);
-  font-weight: 600;
+}
+
+.exercise-input__char--active {
+  color: #4338ca;
 }
 
 .exercise-success {

--- a/src/App.css
+++ b/src/App.css
@@ -4,25 +4,30 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2.5rem 1.25rem 3rem;
+  padding: 1.75rem 1.25rem 2.5rem;
   background:
-    radial-gradient(circle at 15% 20%, rgba(99, 102, 241, 0.18), transparent 60%),
-    radial-gradient(circle at 85% 15%, rgba(56, 189, 248, 0.22), transparent 55%),
-    radial-gradient(circle at 20% 90%, rgba(168, 85, 247, 0.18), transparent 50%),
+    radial-gradient(circle at 15% 20%, rgba(99, 102, 241, 0.16), transparent 58%),
+    radial-gradient(circle at 85% 18%, rgba(56, 189, 248, 0.18), transparent 52%),
+    radial-gradient(circle at 22% 88%, rgba(168, 85, 247, 0.16), transparent 48%),
     #e2e8f0;
   overflow-x: hidden;
 }
 
 .app-card {
-  width: min(860px, 100%);
-  background: rgba(255, 255, 255, 0.94);
-  border-radius: 24px;
-  padding: 2.2rem 2.4rem;
-  box-shadow: 0 36px 70px -46px rgba(15, 23, 42, 0.32);
-  backdrop-filter: blur(10px);
+  width: min(1080px, 100%);
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 26px;
+  padding: 2rem 2.4rem;
+  box-shadow: 0 32px 70px -46px rgba(15, 23, 42, 0.3);
+  backdrop-filter: blur(12px);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.4rem;
+}
+
+.app-card--exercise {
+  gap: 1.75rem;
+  padding-block: 2.2rem;
 }
 
 .app-header {
@@ -37,8 +42,8 @@
 }
 
 .app-header p {
-  margin: 0.85rem auto 0;
-  max-width: 640px;
+  margin: 0.75rem auto 0;
+  max-width: 680px;
   font-size: 1rem;
   line-height: 1.85;
   color: #475569;
@@ -195,14 +200,36 @@
 }
 
 .card {
-  background: rgba(248, 250, 252, 0.9);
-  border-radius: 20px;
-  padding: 1.65rem 1.8rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 26px 70px -60px rgba(15, 23, 42, 0.4);
+  background: rgba(248, 250, 252, 0.92);
+  border-radius: 22px;
+  padding: 1.6rem 1.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 26px 70px -62px rgba(15, 23, 42, 0.38);
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 1.05rem;
+}
+
+.exercise-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(280px, 0.9fr);
+  gap: 1.6rem;
+}
+
+.exercise-layout__main,
+.exercise-layout__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.exercise-layout__main .card,
+.exercise-layout__sidebar .card {
+  height: 100%;
+}
+
+.card--config .field {
+  flex-grow: 1;
 }
 
 .card__header h3 {
@@ -239,20 +266,27 @@
 
 
 .typing-card {
-  gap: 1rem;
+  gap: 1.2rem;
+  flex: 1;
 }
 
 .exercise-input {
   position: relative;
+  border-radius: 18px;
+  border: 1px solid rgba(99, 102, 241, 0.26);
+  background: #ffffff;
+  padding: 1.05rem 1.3rem;
+  transition: border 0.3s ease, box-shadow 0.3s ease;
 }
 
 .exercise-input__overlay {
   position: absolute;
   inset: 0;
-  padding: 0.85rem 1rem;
+  padding: 1.05rem 1.3rem;
   pointer-events: none;
-  font-size: 1rem;
-  line-height: 1.7;
+  font-size: 1.1rem;
+  line-height: 1.85;
+  letter-spacing: 0.01em;
   white-space: pre-wrap;
   color: #1f2937;
 }
@@ -263,13 +297,23 @@
 }
 
 .exercise-input__field {
+  width: 100%;
   color: transparent;
   caret-color: #4338ca;
   background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 1.1rem;
+  line-height: 1.85;
 }
 
 .exercise-input__field:focus {
-  background: transparent;
+  outline: none;
+}
+
+.exercise-input:focus-within {
+  border-color: #7c3aed;
+  box-shadow: 0 22px 48px -36px rgba(124, 58, 237, 0.7);
 }
 
 .exercise-input__char {
@@ -278,7 +322,7 @@
 }
 
 .exercise-input__char--pending {
-  color: #94a3b8;
+  color: #b6c2d9;
 }
 
 .exercise-input__char--correct {
@@ -321,11 +365,11 @@
 }
 
 .field__control {
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  border-radius: 14px;
-  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  padding: 0.9rem 1.05rem;
   font-size: 1rem;
-  background: rgba(255, 255, 255, 0.96);
+  background: #ffffff;
   transition: border 0.3s ease, box-shadow 0.3s ease;
 }
 
@@ -341,7 +385,7 @@
 }
 
 .field__control--textarea {
-  min-height: 140px;
+  min-height: 180px;
   resize: vertical;
   line-height: 1.9;
 }
@@ -367,7 +411,7 @@
 
 @media (max-width: 900px) {
   .app-card {
-    padding: 2.25rem 2.25rem;
+    padding: 1.85rem 1.95rem;
   }
 }
 
@@ -394,7 +438,7 @@
 
 @media (max-width: 520px) {
   .app-shell {
-    padding: 2.5rem 1.2rem;
+    padding: 2.2rem 1.2rem;
   }
 
   .app-card {
@@ -403,5 +447,21 @@
 
   .card {
     padding: 1.5rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .exercise-layout {
+    grid-template-columns: minmax(0, 1.5fr) minmax(260px, 0.9fr);
+  }
+}
+
+@media (max-width: 880px) {
+  .exercise-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .exercise-layout__sidebar {
+    order: -1;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
 
     return (
         <div className="app-shell">
-            <main className="app-card">
+            <main className={`app-card ${exerciseMode ? "app-card--exercise" : ""}`}>
                 <header className="app-header">
                     <h1>🗣️ یادگیری زبان با تایپ</h1>
                     <p>{hintText}</p>
@@ -67,10 +67,14 @@ function App() {
                 </div>
 
                 {exerciseMode ? (
-                    <>
-                        <ExerciseConfig text={exerciseText} onTextChange={setExerciseText} />
-                        <TypingExercise targetText={exerciseText} voice={voice} />
-                    </>
+                    <div className="exercise-layout">
+                        <div className="exercise-layout__main">
+                            <TypingExercise targetText={exerciseText} voice={voice} />
+                        </div>
+                        <aside className="exercise-layout__sidebar" aria-label="تنظیمات متن تمرین">
+                            <ExerciseConfig text={exerciseText} onTextChange={setExerciseText} />
+                        </aside>
+                    </div>
                 ) : (
                     <section className="card">
                         <header className="card__header">

--- a/src/components/ExerciseConfig.tsx
+++ b/src/components/ExerciseConfig.tsx
@@ -11,7 +11,7 @@ export default function ExerciseConfig({ text, onTextChange }: Props) {
     };
 
     return (
-        <section className="card">
+        <section className="card card--config">
             <header className="card__header">
                 <h3>متن تمرین</h3>
                 <p>جمله یا پاراگراف موردنظر را بنویس تا همان متن را در تمرین تایپ کنی.</p>

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -28,8 +28,10 @@ export default function InputBox({ voice, onWordComplete }: Props) {
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         const trimmed = value.trimEnd();
+        const wasTrailingSpace = text.endsWith(" ");
+        const isAddingSpace = value.endsWith(" ") && !wasTrailingSpace;
 
-        if (value.endsWith(" ") && trimmed.length > text.trimEnd().length) {
+        if (isAddingSpace) {
             const completedWord = trimmed.split(/\s+/).pop();
             if (completedWord) {
                 speakWord(completedWord);

--- a/src/components/TypingExercise.tsx
+++ b/src/components/TypingExercise.tsx
@@ -59,6 +59,8 @@ export default function TypingExercise({ targetText, voice }: Props) {
     };
 
     const characters = useMemo(() => {
+        const activeIndex = input.length < targetText.length ? input.length : -1;
+
         return targetText.split("").map((char, index) => {
             let state: "pending" | "correct" | "incorrect" = "pending";
 
@@ -69,8 +71,17 @@ export default function TypingExercise({ targetText, voice }: Props) {
                         : "incorrect";
             }
 
+            const isActive = index === activeIndex;
+            const className = [
+                "exercise-input__char",
+                `exercise-input__char--${state}`,
+                isActive ? "exercise-input__char--active" : "",
+            ]
+                .filter(Boolean)
+                .join(" ");
+
             return (
-                <span key={`${char}-${index}`} className={`exercise-input__char exercise-input__char--${state}`}>
+                <span key={`${char}-${index}`} className={className}>
                     {char === " " ? "\u00A0" : char}
                 </span>
             );

--- a/src/components/TypingExercise.tsx
+++ b/src/components/TypingExercise.tsx
@@ -106,7 +106,7 @@ export default function TypingExercise({ targetText, voice }: Props) {
 
                 <input
                     type="text"
-                    className="input-box exercise-input__field"
+                    className="exercise-input__field"
                     value={input}
                     onChange={handleChange}
                     placeholder=""


### PR DESCRIPTION
## Summary
- ensure the free practice input speaks the completed word whenever a new trailing space is added
- simplify the typing exercise overlay styling so text looks natural while highlighting the active character

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d680550ec8832384b98e7b922b4fcc